### PR TITLE
Fix _resolveIP() crash due to non-iterable exception, add missing reject callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,17 +26,17 @@ class ICMP {
     }
 
     _resolveIP() {
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
             if (!this.ip) {
                 if (net.isIPv4(this.host)) {
                     this.ip = this.host;
                     return resolve();
                 }
 
-                dns.resolve4(this.host, (err, [ip]) => {
+                dns.resolve4(this.host, (err, ips) => {
                     if (err) return reject(err);
 
-                    this.ip = ip;
+                    this.ip = ips[0];
 
                     resolve();
                 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "icmp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icmp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Internet Control Message Protocol in Node",
   "main": "index.js",
   "directories": {

--- a/test.js
+++ b/test.js
@@ -49,16 +49,32 @@ describe('Online ICMP', () => {
             const ping = icmp.ping('www.google.com');
 
             try {
-                it('ip property is an IP', async (done) => {
-                    const { ip } = await ping;
-
-                    assert(net.isIP(ip) >= 0, true);
+                it('ip property is an IP', (done) => {
+                    ping.then(({ ip }) => {
+                      assert(net.isIP(ip) >= 0, true);
+                      done();
+                    });
                 });
 
                 it('open property is true', async () => {
                     const { open } = await ping;
 
                     assert(open, true);
+                });
+            } catch (e) { assert.fail(e) }
+        });
+
+        describe('ping a non-existing DNS', () => {
+            const ping = icmp.ping('this-dns-does.not.exist');
+
+            try {
+                it('rejects with the error object', (done) => {
+                    ping.catch(error => {
+                        assert(error.message.indexOf('ENOTFOUND this-dns-does.not.exist'));
+                        assert(error.code === 'ENOTFOUND');
+                        assert(error.hostname === 'this-dns-does.not.exist');
+                        done();
+                    });
                 });
             } catch (e) { assert.fail(e) }
         });

--- a/test.js
+++ b/test.js
@@ -43,40 +43,41 @@ describe('Online ICMP', () => {
     });
 
     check.then(res => {
-        if(!res) return;
+        if (!res) return;
 
         describe('ping www.google.com', () => {
             const ping = icmp.ping('www.google.com');
 
             try {
-                it('ip property is an IP', (done) => {
-                    ping.then(({ ip }) => {
-                      assert(net.isIP(ip) >= 0, true);
-                      done();
-                    });
+                it('ip property is an IP', async () => {
+                    const { ip } = await ping;
+
+                    assert(net.isIP(ip) !== 0);
                 });
 
                 it('open property is true', async () => {
                     const { open } = await ping;
 
-                    assert(open, true);
+                    assert(open);
                 });
             } catch (e) { assert.fail(e) }
         });
 
-        describe('ping a non-existing DNS', () => {
-            const ping = icmp.ping('this-dns-does.not.exist');
-
+        describe('ping a non-existing DNS', async () => {
             try {
-                it('rejects with the error object', (done) => {
-                    ping.catch(error => {
-                        assert(error.message.indexOf('ENOTFOUND this-dns-does.not.exist'));
-                        assert(error.code === 'ENOTFOUND');
-                        assert(error.hostname === 'this-dns-does.not.exist');
-                        done();
+                await icmp.ping('this-dns-does.not.exist');
+            } catch (error) {
+                try {
+                    it('rejects with the error object', (done) => {
+                        ping.catch(error => {
+                            assert(error.message.indexOf('ENOTFOUND this-dns-does.not.exist'));
+                            assert(error.code === 'ENOTFOUND');
+                            assert(error.hostname === 'this-dns-does.not.exist');
+                            done();
+                        })
                     });
-                });
-            } catch (e) { assert.fail(e) }
+                } catch (e) { assert.fail(e) }
+            }
         });
     });
 });


### PR DESCRIPTION
### Reason for the PR
The `_resolveIP()` call crashes the entire application due to a chain reaction, when providing a DNS name which cannot be resolved:
1. `dns.resolve4(this.host, (err, [ip])`
> The second argument of the `dns.resolve4` callback function returns `undefined`, thus is not an iterable. This crashes the application.
2. `return new Promise(resolve => ...` and `if (err) return reject(err);`
> The `reject` callback is missing, so it crashes the application if `dns.resolve4` returns an error;